### PR TITLE
Export policy ids

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,7 @@
+output "non_urgent_policy_id" {
+  value = newrelic_alert_policy.non_urgent.id
+}
+
+output "urgent_policy_id" {
+  value = newrelic_alert_policy.urgent.id
+}


### PR DESCRIPTION
Export the created policy ids so that other alert conditions created outside of this module can be attached to those policies. This was possible using a data resource, but that forced the recreation of the resources. Using this approach, we avoid that.