### PR TITLE
Fix issue with disabled pagerduty notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ provider "newrelic" {
 
 module "newrelic_monitoring" {
   source  = "vistaprint/monitoring/newrelic"
-  version = "3.0.0"
+  version = ">= 3.0.0, < 4.0.0"
 
   newrelic_account_id = Your New Relic account id
 
@@ -33,8 +33,8 @@ module "newrelic_monitoring" {
 
   # some fields ommitted (see previous example)
   
-  alert_high_latency_urgent_duration     = 350 # milliseconds
-  alert_high_latency_non_urgent_duration = 400  # seconds
+  alert_high_latency_urgent_duration     = 350 # seconds
+  alert_high_latency_non_urgent_duration = 400 # seconds
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ provider "newrelic" {
 
 module "newrelic_monitoring" {
   source  = "vistaprint/monitoring/newrelic"
-  version = "2.0.0"
+  version = "3.0.0"
 
   newrelic_account_id = Your New Relic account id
 
@@ -24,17 +24,23 @@ module "newrelic_monitoring" {
 }
 ```
 
-See [variables.tf](./variables.tf) for more information on the input variables that the module accepts. For instance, the default values for an alert's duration and threshold can be overridden. The following example shows how to do so:
+See [variables.tf](./variables.tf) for more information on the input variables that the module accepts. For instance, to enable 4xx alerts on a given endpoint you can do:
 
 ```hcl
 module "newrelic_monitoring" {
   source  = "vistaprint/monitoring/newrelic"
-  version = "1.0.0"
+  version = "3.0.0"
 
   # some fields ommitted (see previous example)
-
-  alert_error_rate_5xx_duration  = 600 # seconds
-  alert_error_rate_5xx_threshold = 5  # percentage
+  status_code_alerts = [
+    {
+      name                = "Your app name: too many sustained 4xx errors"
+      status_code_pattern = "4%"
+      urgent              = false
+      duration            = 300
+      threshold           = 30
+    }
+  ]  
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ module "newrelic_monitoring" {
   source  = "vistaprint/monitoring/newrelic"
   version = ">= 3.0.0, < 4.0.0"
 
-  # some fields ommitted (see previous example)
+  # some fields ommitted (see first example)
+
   status_code_alerts = [
     {
       name                = "Your app name: too many sustained 4xx errors"

--- a/README.md
+++ b/README.md
@@ -24,12 +24,28 @@ module "newrelic_monitoring" {
 }
 ```
 
-See [variables.tf](./variables.tf) for more information on the input variables that the module accepts. For instance, to enable 4xx alerts on a given endpoint you can do:
+See [variables.tf](./variables.tf) for more information on the input variables that the module accepts. For instance, the default values for an alert's duration and threshold can be overridden. The following example shows how to do so:
 
 ```hcl
 module "newrelic_monitoring" {
   source  = "vistaprint/monitoring/newrelic"
-  version = "3.0.0"
+  version = ">= 3.0.0, < 4.0.0"
+
+  # some fields ommitted (see previous example)
+  
+  alert_high_latency_urgent_duration     = 350 # milliseconds
+  alert_high_latency_non_urgent_duration = 400  # seconds
+}
+```
+
+### Defining alerts on status codes
+
+To enable alerts for status codes, you need to use the `status_code_alerts` variable. For instance, if you want to enable them for 4xx errors, you can do:
+
+```hcl
+module "newrelic_monitoring" {
+  source  = "vistaprint/monitoring/newrelic"
+  version = ">= 3.0.0, < 4.0.0"
 
   # some fields ommitted (see previous example)
   status_code_alerts = [

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ module "newrelic_monitoring" {
 
   # some fields ommitted (see previous example)
   
-  alert_high_latency_urgent_duration     = 350 # seconds
-  alert_high_latency_non_urgent_duration = 400 # seconds
+  alert_high_latency_urgent_duration  = 350  # seconds
+  alert_high_latency_urgent_threshold = 1500 # milliseconds
 }
 ```
 

--- a/pagerduty.tf
+++ b/pagerduty.tf
@@ -82,6 +82,8 @@ resource "newrelic_notification_channel" "pagerduty_non_urgent_channel" {
 }
 
 resource "newrelic_workflow" "non_urgent_workflow" {
+  count = var.enable_pagerduty_notifications ? 1 : 0
+
   name                  = "${var.newrelic_app_name}: PagerDuty Non Urgent Workflow"
   muting_rules_handling = "NOTIFY_ALL_ISSUES"
 
@@ -102,6 +104,8 @@ resource "newrelic_workflow" "non_urgent_workflow" {
 }
 
 resource "newrelic_workflow" "urgent_workflow" {
+  count = var.enable_pagerduty_notifications ? 1 : 0
+
   name                  = "${var.newrelic_app_name}: PagerDuty Urgent Workflow"
   muting_rules_handling = "NOTIFY_ALL_ISSUES"
 


### PR DESCRIPTION
When disabling pagerduty notifications, terraform fails with the following error:

```
│ Error: Invalid index
│ 
│   on .terraform/modules/newrelic_monitoring/pagerduty.tf line 120, in resource "newrelic_workflow" "urgent_workflow":
│  120:     channel_id = newrelic_notification_channel.pagerduty_urgent_channel[0].id
│     ├────────────────
│     │ newrelic_notification_channel.pagerduty_urgent_channel is empty tuple
│ 
│ The given key does not identify an element in this collection value: the collection has no elements.
╵
```
